### PR TITLE
Add crossOrigin parameter to createThumbnailFromUrl declaration

### DIFF
--- a/dropzone.d.ts
+++ b/dropzone.d.ts
@@ -171,7 +171,7 @@ declare class Dropzone {
 
 	createThumbnail(file:DropzoneFile, callback?:(...args:any[]) => void):any;
 
-	createThumbnailFromUrl(file:DropzoneFile, url:string, callback?:(...args:any[]) => void):any;
+	createThumbnailFromUrl(file:DropzoneFile, url:string, callback?:(...args:any[]) => void, crossOrigin?:string):any;
 
 	on(eventName:string, callback:(...args:any[]) => void):void;
 


### PR DESCRIPTION
Dropzone.js script function createThumbnailFromUrl has four parameters

createThumbnailFromUrl: (file, imageUrl, callback, crossOrigin)

In your repository this function has only three